### PR TITLE
#348 import view has unexpected file upload button

### DIFF
--- a/AudioCuesheetEditor/Pages/ViewModeImport.razor
+++ b/AudioCuesheetEditor/Pages/ViewModeImport.razor
@@ -39,11 +39,11 @@ along with Foobar.  If not, see
                 <Card>
                     <CardHeader><CardTitle Size="2">@_localizer["Select files for import"]</CardTitle></CardHeader>
                     <CardBody>
-                        <div class="dragNDropFile mb-3" ondragover="dragOver(event, this)" ondragleave="dragLeave(event, this)" ondrop="dropFiles(event, this, 'dropFileInput')">
+                        <Field class="dragNDropFile mb-3" ondragover="dragOver(event, this)" ondragleave="dragLeave(event, this)" ondrop="dropFiles(event, this, 'dropFileInput')">
                             <svg class="dragNDropFileIcon" xmlns="http://www.w3.org/2000/svg" width="50" height="43" viewBox="0 0 50 43"><path d="M48.4 26.5c-.9 0-1.7.7-1.7 1.7v11.6h-43.3v-11.6c0-.9-.7-1.7-1.7-1.7s-1.7.7-1.7 1.7v13.2c0 .9.7 1.7 1.7 1.7h46.7c.9 0 1.7-.7 1.7-1.7v-13.2c0-1-.7-1.7-1.7-1.7zm-24.5 6.1c.3.3.8.5 1.2.5.4 0 .9-.2 1.2-.5l10-11.6c.7-.7.7-1.7 0-2.4s-1.7-.7-2.4 0l-7.1 8.3v-25.3c0-.9-.7-1.7-1.7-1.7s-1.7.7-1.7 1.7v25.3l-7.1-8.3c-.7-.7-1.7-.7-2.4 0s-.7 1.7 0 2.4l10 11.6z"></path></svg>
                             <FileEdit id="dropFileInput" Class="hideInput" Multiple Filter="@dragNDropUploadFilter" Changed="OnDropFileChanged" AutoReset="false"></FileEdit>
-                            <label for="dropFileInput">@((MarkupString)(_localizer["Choose file or drag it here"].ToString()))</label>
-                        </div>
+                            <FieldLabel for="dropFileInput">@((MarkupString)(_localizer["Choose file or drag it here"].ToString()))</FieldLabel>
+                        </Field>
                         @foreach (var invalidFileName in invalidDropFileNames)
                         {
                             <Alert @ref="alertInvalidFile" Color="Color.Danger" Visible Dismisable>

--- a/AudioCuesheetEditor/Pages/ViewModeImport.razor
+++ b/AudioCuesheetEditor/Pages/ViewModeImport.razor
@@ -41,7 +41,7 @@ along with Foobar.  If not, see
                     <CardBody>
                         <Field class="dragNDropFile mb-3" ondragover="dragOver(event, this)" ondragleave="dragLeave(event, this)" ondrop="dropFiles(event, this, 'dropFileInput')">
                             <svg class="dragNDropFileIcon" xmlns="http://www.w3.org/2000/svg" width="50" height="43" viewBox="0 0 50 43"><path d="M48.4 26.5c-.9 0-1.7.7-1.7 1.7v11.6h-43.3v-11.6c0-.9-.7-1.7-1.7-1.7s-1.7.7-1.7 1.7v13.2c0 .9.7 1.7 1.7 1.7h46.7c.9 0 1.7-.7 1.7-1.7v-13.2c0-1-.7-1.7-1.7-1.7zm-24.5 6.1c.3.3.8.5 1.2.5.4 0 .9-.2 1.2-.5l10-11.6c.7-.7.7-1.7 0-2.4s-1.7-.7-2.4 0l-7.1 8.3v-25.3c0-.9-.7-1.7-1.7-1.7s-1.7.7-1.7 1.7v25.3l-7.1-8.3c-.7-.7-1.7-.7-2.4 0s-.7 1.7 0 2.4l10 11.6z"></path></svg>
-                            <FileEdit id="dropFileInput" Class="hideInput" Multiple Filter="@dragNDropUploadFilter" Changed="OnDropFileChanged" AutoReset="false"></FileEdit>
+                            <FileEdit id="dropFileInput" Multiple Filter="@dragNDropUploadFilter" Changed="OnDropFileChanged" AutoReset="false"></FileEdit>
                             <FieldLabel for="dropFileInput">@((MarkupString)(_localizer["Choose file or drag it here"].ToString()))</FieldLabel>
                         </Field>
                         @foreach (var invalidFileName in invalidDropFileNames)

--- a/AudioCuesheetEditor/wwwroot/css/app.css
+++ b/AudioCuesheetEditor/wwwroot/css/app.css
@@ -89,7 +89,7 @@ a, .btn-link {
     z-index: -1;
 }
 
-    .hideInput + label {
+.dragNDropFile > .form-label {
         max-width: 80%;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/AudioCuesheetEditor/wwwroot/css/app.css
+++ b/AudioCuesheetEditor/wwwroot/css/app.css
@@ -80,7 +80,7 @@ a, .btn-link {
         cursor: move;
     }
 
-.hideInput {
+.hideInput, .dragNDropFile div:has(> .hideInput) {
     width: 0.1px;
     height: 0.1px;
     opacity: 0;

--- a/AudioCuesheetEditor/wwwroot/css/app.css
+++ b/AudioCuesheetEditor/wwwroot/css/app.css
@@ -80,7 +80,7 @@ a, .btn-link {
         cursor: move;
     }
 
-.hideInput, .dragNDropFile div:has(> .hideInput) {
+.dragNDropFile > .input-group {
     width: 0.1px;
     height: 0.1px;
     opacity: 0;


### PR DESCRIPTION
### Bug Fix for - #348 import view has unexpected file upload button 

## Main Changes

- Refactored html tags to use the relevent blazorise component tags as suggested in the blazorise docs,
![image](https://github.com/NeoCoderMatrix86/AudioCuesheetEditor/assets/97601531/b741334c-9174-4ddf-b437-a050f880a854)

- Fixed css selector bug. The FieldEdit component after the build turns into a div with two children a label and an input. For some reason putting a class on the field edit component, after the build, only puts that class on the child input element rather than the parent div for the component. This was also causing the next css selector problems in the file as it was trying to style a label element that we declared after the fieldedit component but it was using the class on the field element with the get next sibling selector (+) but since the class was being put on the child rather than the parent it didn't have the outside label as it's next sibling. I changed this around to select the elements based on them being inside of the .dragNDropFiles container instead fixing the issue we had! :)

![image](https://github.com/NeoCoderMatrix86/AudioCuesheetEditor/assets/97601531/65ae1350-dc16-4fdb-83b7-abcb0903805d)

![image](https://github.com/NeoCoderMatrix86/AudioCuesheetEditor/assets/97601531/85646e15-d66e-4355-a4c4-cee8fa9fd20b)

