### PR TITLE
Proposed fix - "Fix #456: Localize export-to-text placeholders and ad…

### DIFF
--- a/AudioCuesheetEditor/Shared/Dialogs/GenerateExportDialog.de.resx
+++ b/AudioCuesheetEditor/Shared/Dialogs/GenerateExportDialog.de.resx
@@ -177,4 +177,21 @@
   <data name="Content" xml:space="preserve">
     <value>Inhalt</value>
   </data>
+
+  <data name="Placeholder_Artist" xml:space="preserve">
+    <value>Künstler</value>
+  </data>
+  <data name="Placeholder_Title" xml:space="preserve">
+    <value>Titel</value>
+  </data>
+  <data name="Placeholder_Album" xml:space="preserve">
+    <value>Album</value>
+  </data>
+
+  <data name="Placeholder_CuesheetTitle" xml:space="preserve">
+    <value>Cuesheet Titel</value>
+  </data>
+  <data name="Placeholder_Performer" xml:space="preserve">
+    <value>Interpret</value>
+  </data>
 </root>

--- a/AudioCuesheetEditor/Shared/Dialogs/GenerateExportDialog.razor
+++ b/AudioCuesheetEditor/Shared/Dialogs/GenerateExportDialog.razor
@@ -55,14 +55,10 @@ along with Foobar.  If not, see
                         <MudMenu Label="@_localizer["Add placeholder"]" Color="Color.Primary" Variant="Variant.Filled" EndIcon="@Icons.Material.Outlined.KeyboardArrowDown" Class="mt-1" Style="height: 56px;">
                             @foreach (var placeholder in Exportprofile.AvailableCuesheetSchemes)
                             {
-                                <MudMenuItem OnClick="() => 
-                                {
-                                    if (exportOptions.SelectedExportProfile != null)
-                                    {
-                                        exportOptions.SelectedExportProfile.SchemeHead += placeholder.Value;
-                                    }
-                                }">
-                                    @_localizer[placeholder.Key]
+                                <MudMenuItem
+                                    OnClick="() => InsertCuesheetPlaceholder(placeholder.Value)"
+                                    Title="@(_localizer["Placeholder_"+placeholder.Key] + " (" + placeholder.Value + ")")">
+                                    @_localizer["Placeholder_" + placeholder.Key]
                                 </MudMenuItem>
                             }
                         </MudMenu>
@@ -72,15 +68,12 @@ along with Foobar.  If not, see
                         <MudMenu Label="@_localizer["Add placeholder"]" Color="Color.Primary" Variant="Variant.Filled" EndIcon="@Icons.Material.Outlined.KeyboardArrowDown" Class="mt-1" Style="height: 56px;">
                             @foreach (var placeholder in Exportprofile.AvailableTrackSchemes)
                             {
-                                <MudMenuItem OnClick="() =>
-                                {
-                                    if (exportOptions.SelectedExportProfile != null)
-                                    {
-                                        exportOptions.SelectedExportProfile.SchemeTracks += placeholder.Value;
-                                    }
-                                }">
-                                    @_localizer[placeholder.Key]
+                                <MudMenuItem
+                                    OnClick="() => InsertTrackPlaceholder(placeholder.Value)"
+                                    Title="@(_localizer["Placeholder_"+placeholder.Key] + " (" + placeholder.Value + ")")">
+                                    @_localizer["Placeholder_" + placeholder.Key]
                                 </MudMenuItem>
+
                             }
                         </MudMenu>
                     </MudStack>
@@ -89,14 +82,10 @@ along with Foobar.  If not, see
                         <MudMenu Label="@_localizer["Add placeholder"]" Color="Color.Primary" Variant="Variant.Filled" EndIcon="@Icons.Material.Outlined.KeyboardArrowDown" Class="mt-1" Style="height: 56px;">
                             @foreach (var placeholder in Exportprofile.AvailableCuesheetSchemes)
                             {
-                                <MudMenuItem OnClick="() =>
-                                {
-                                    if (exportOptions.SelectedExportProfile != null)
-                                    {
-                                        exportOptions.SelectedExportProfile.SchemeFooter += placeholder.Value;
-                                    }
-                                }">
-                                    @_localizer[placeholder.Key]
+                                <MudMenuItem
+                                    OnClick="() => InsertCuesheetPlaceholder(placeholder.Value)"
+                                    Title="@(_localizer["Placeholder_"+placeholder.Key] + " (" + placeholder.Value + ")")">
+                                    @_localizer["Placeholder_" + placeholder.Key]
                                 </MudMenuItem>
                             }
                         </MudMenu>
@@ -125,7 +114,7 @@ along with Foobar.  If not, see
 
 @code {
     ExportOptions? exportOptions;
-    IEnumerable<Exportfile> exportFiles = [];
+    IEnumerable<Exportfile> exportFiles = Array.Empty<Exportfile>();
     Boolean configureExportCompleted = false;
 
     protected override void Dispose(bool disposing)
@@ -213,4 +202,17 @@ along with Foobar.  If not, see
             configureExportCompleted = exportFiles.Any();
         }
     }
+
+    void InsertTrackPlaceholder(string token)
+    {
+        if (exportOptions?.SelectedExportProfile != null)
+            exportOptions.SelectedExportProfile.SchemeTracks += token;
+    }
+
+    void InsertCuesheetPlaceholder(string token)
+    {
+        if (exportOptions?.SelectedExportProfile != null)
+            exportOptions.SelectedExportProfile.SchemeHead += token;
+    }
+
 }

--- a/AudioCuesheetEditor/Shared/Dialogs/GenerateExportDialog.resx
+++ b/AudioCuesheetEditor/Shared/Dialogs/GenerateExportDialog.resx
@@ -177,4 +177,22 @@
   <data name="Content" xml:space="preserve">
     <value>Content</value>
   </data>
+
+  <data name="Placeholder_Artist" xml:space="preserve">
+    <value>Artist</value>
+  </data>
+  <data name="Placeholder_Title" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="Placeholder_Album" xml:space="preserve">
+    <value>Album</value>
+  </data>
+
+  <data name="Placeholder_CuesheetTitle" xml:space="preserve">
+    <value>Cuesheet title</value>
+  </data>
+  <data name="Placeholder_Performer" xml:space="preserve">
+    <value>Performer</value>
+  </data>
+  
 </root>


### PR DESCRIPTION
### Fixes #456: Localize export-to-text placeholders

- Added localized placeholder entries to GenerateExportDialog.resx and GenerateExportDialog.de.resx
- Updated GenerateExportDialog.razor to use localized placeholder keys for dropdowns
- Added German translations for placeholder labels
- Technical placeholder values remain unchanged for export logic



